### PR TITLE
Add preference for customizing a default action on a Gif search result

### DIFF
--- a/extensions/gif-search/package.json
+++ b/extensions/gif-search/package.json
@@ -47,6 +47,27 @@
       "required": false,
       "label": "Show GIF Preview",
       "description": "Shows a large preview of the selected gif in search results."
+    },
+    {
+      "name": "defaultAction",
+      "type": "dropdown",
+      "required": false,
+      "title": "Default Action",
+      "description": "Customize what happens when hitting ENTER on a Gif",
+      "data": [
+        {
+          "title": "Open in Browser",
+          "value": "openInBrowser"
+        },
+        {
+          "title": "Copy GIF URL to Clipboard",
+          "value": "copyGifUrl"
+        },
+        {
+          "title": "Copy Page URL to Clipboard",
+          "value": "copyPageUrl"
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/extensions/gif-search/src/components/GifResult.tsx
+++ b/extensions/gif-search/src/components/GifResult.tsx
@@ -1,29 +1,44 @@
 import { Action, ActionPanel, List } from "@raycast/api";
 
 import { IGif, renderGifMarkdownDetails } from "../models/gif";
-import { getShowPreview } from "../preferences";
+import { getShowPreview, getDefaultAction } from "../preferences";
 
 export function GifResult(props: { item: IGif; index: number }) {
   const { preview_gif_url, title, url, gif_url } = props.item;
 
   const showPreview = getShowPreview();
 
+  const openInBrowser = <Action.OpenInBrowser key="openInBrowser" url={url} />;
+  const copyGif = (
+    <Action.CopyToClipboard key="copyGifUrl" title="Copy GIF URL to Clipboard" content={stripQParams(gif_url)} />
+  );
+  const copyUrl = (
+    <Action.CopyToClipboard
+      key="copyPageUrl"
+      title="Copy Page URL to Clipboard"
+      content={url}
+      shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
+    />
+  );
+
+  const actions = [openInBrowser, copyGif, copyUrl];
+  const defaultAction = getDefaultAction();
+  for (let index = 0; index < actions.length; index++) {
+    const action = actions[index];
+
+    if (action.key == defaultAction) {
+      // Move matching action to the front of the array to make it the default
+      actions.splice(index, 1);
+      actions.unshift(action);
+    }
+  }
+
   return (
     <List.Item
       title={title}
       icon={{ source: preview_gif_url }}
       detail={showPreview && <List.Item.Detail markdown={renderGifMarkdownDetails(props.item)} />}
-      actions={
-        <ActionPanel title={title}>
-          <Action.OpenInBrowser url={url} />
-          <Action.CopyToClipboard title="Copy GIF URL to Clipboard" content={stripQParams(gif_url)} />
-          <Action.CopyToClipboard
-            title="Copy Page URL to Clipboard"
-            content={url}
-            shortcut={{ modifiers: ["cmd", "shift"], key: "c" }}
-          />
-        </ActionPanel>
-      }
+      actions={<ActionPanel title={title}>{actions}</ActionPanel>}
     />
   );
 }

--- a/extensions/gif-search/src/preferences.ts
+++ b/extensions/gif-search/src/preferences.ts
@@ -2,6 +2,7 @@ import { getPreferenceValues } from "@raycast/api";
 
 export const API_KEY = "apiKey";
 export const SHOW_PREVIEW = "showGifPreview";
+export const DEFAULT_ACTION = "defaultAction";
 
 export type ServiceName = "giphy" | "tenor";
 export const GIF_SERVICE: { [name: string]: ServiceName } = {
@@ -27,4 +28,8 @@ export function getAPIKey(serviceName: ServiceName) {
 
 export function getShowPreview() {
   return getPrefs()[SHOW_PREVIEW];
+}
+
+export function getDefaultAction() {
+  return getPrefs()[DEFAULT_ACTION];
 }


### PR DESCRIPTION
## Description

Adds a preference to allow the user to customize what happens by default (aka when hitting ENTER) on a GIF search result. Defaults to "Open in Browser". Whatever is chosen as the default will be moved to the top.

<img width="310" alt="image" src="https://user-images.githubusercontent.com/136007/157575237-1996d489-1db5-4a57-947c-b18242167027.png">

### Default Option
<img width="886" alt="image" src="https://user-images.githubusercontent.com/136007/157575359-2f78d013-fba7-40ac-82db-3c9a2f154ac7.png">

### Copy to Clipboard as Default Action

<img width="886" alt="image" src="https://user-images.githubusercontent.com/136007/157575410-e5eed4ff-bf1b-4c0c-8909-d15c6d2ae4d4.png">

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed in the `media` folder
